### PR TITLE
[ISSUE #3][Bug] Standalone diagrams have inheritance classes declared outside any packages

### DIFF
--- a/DMA_Plantuml/src/DMA_Plantuml.hpp
+++ b/DMA_Plantuml/src/DMA_Plantuml.hpp
@@ -9,7 +9,7 @@
 /**
  *
  * Module:   DMA_Plantuml
- * Version:  1.0.2
+ * Version:  1.0.3
  * Author:   Vladyslav Goncharuk ( svlad1990@gmail.com )
  *
  * ////////////////////////////////////////////////////////////////////////////
@@ -739,7 +739,7 @@ namespace DMA
 
         struct tClassData : public tBaseData
         {
-            virtual const eItemType& getType() const override;            
+            virtual const eItemType& getType() const override;
         };
 
         typedef std::shared_ptr<tClassData> tClassDataPtr;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DMA_Plantuml
 
 - Module:   DMA_Plantuml
-- Version:  1.0.2
+- Version:  1.0.3
 - Author:   Vladyslav Goncharuk ( svlad1990@gmail.com )
 
 ----


### PR DESCRIPTION
## [ISSUE #3][Bug] Standalone diagrams have inheritance classes declared outside any packages

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Fix for issue #3 - Standalone diagrams have inheritance classes declared outside any packages

#### Verification criteria:

- Checked manually on Windows OS
- All sanity checks on the Github were passed