### PR TITLE
[ISSUE #6][DIAGRAMS] Add possibility to specify the background color of the generated diagrams

### DIFF
--- a/DMA_Plantuml/src/DMA_Plantuml.cpp
+++ b/DMA_Plantuml/src/DMA_Plantuml.cpp
@@ -217,7 +217,7 @@ namespace DMA
             return result;
         }
 
-        static std::string getClassDiagramInternal(const tPackageMap& packageMap)
+        static std::string getClassDiagramInternal(const tPackageMap& packageMap, const std::string& backgroundColor)
         {
             std::string diagram;
 
@@ -230,6 +230,13 @@ namespace DMA
 
                 diagram.append("@startuml").append(sNewLine);
                 diagram.append(sNewLine);
+
+                if(false == backgroundColor.empty())
+                {
+                    diagram.append("skinparam backgroundColor ").append(backgroundColor);
+                    diagram.append(sNewLine);
+                }
+
                 diagram.append("skinparam wrapWidth 600").append(sNewLine);
 
                 for(const auto& packagePair : packageMap)
@@ -499,7 +506,7 @@ namespace DMA
 
             std::lock_guard<std::mutex> guard(*const_cast<std::mutex*>(&mDataProtector));
 
-            result.diagramContent = getClassDiagramInternal(mPackageMap);
+            result.diagramContent = getClassDiagramInternal(mPackageMap, mBackgroundColor);
             result.bIsSuccessful = true;
 
             return result;
@@ -823,7 +830,7 @@ namespace DMA
                     }
                 }
 
-                result.diagramContent = getClassDiagramInternal(dumpMap);
+                result.diagramContent = getClassDiagramInternal(dumpMap, mBackgroundColor);
                 result.bIsSuccessful = true;
             }
             else
@@ -903,6 +910,12 @@ namespace DMA
 
                 mItemRegistry[pItemData->getItemName()] = pItemData;
             }
+        }
+
+        void Creator::setBackgroundColor(const std::string& color)
+        {
+            std::lock_guard<std::mutex> guard(*const_cast<std::mutex*>(&mDataProtector));
+            mBackgroundColor = color;
         }
         ////////////////////////////////////////////////////////////////
 

--- a/DMA_Plantuml/src/DMA_Plantuml.hpp
+++ b/DMA_Plantuml/src/DMA_Plantuml.hpp
@@ -849,6 +849,14 @@ namespace DMA
                  */
                 void addItem( const tItemName& packageName, const tIItemPtr& pItemData );
 
+                /**
+                 * @brief setBackgroundColor - sets background color for generated diagrams
+                 * @param color - the color to be set. Should be in #FFFFFF format. Be aware, that
+                 * internally no validation of the provided argument is done. Thus, improper usage
+                 * might break the diagram's syntax!
+                 */
+                void setBackgroundColor(const std::string& color);
+
             private:
 
                 /**
@@ -861,6 +869,7 @@ namespace DMA
                 tPackageMap mPackageMap;
                 tItemMap mItemRegistry;
                 bool mbIsinitialized;
+                std::string mBackgroundColor; // used if non-empty
                 std::mutex mDataProtector;
         };
 

--- a/DMA_Plantuml/test/UT_DMA_Plantuml.cpp
+++ b/DMA_Plantuml/test/UT_DMA_Plantuml.cpp
@@ -98,6 +98,22 @@ TEST_F(Test_CClassUnderTest, test_package_diagram_excluded_dependencies_non_empt
     ASSERT_EQ(diagramResult.diagramContent.empty(), false);
 }
 
+TEST_F(Test_CClassUnderTest, test_diagram_background_color)
+{
+    PUML_PACKAGE_BEGIN(test_bg_color)
+        PUML_CLASS_BEGIN(FakeClass)
+        PUML_CLASS_END()
+    PUML_PACKAGE_END()
+
+    DMA::PlantUML::Creator::getInstance().setBackgroundColor("#FFFFFF");
+    auto diagramResult = DMA::PlantUML::Creator::getInstance().getPackageClassDiagram("test_bg_color", true);
+    ASSERT_EQ(diagramResult.bIsSuccessful, true);
+    ASSERT_EQ(diagramResult.diagramContent.empty(), false);
+
+    // we should find color
+    ASSERT_NE(diagramResult.diagramContent.find("skinparam backgroundColor #FFFFFF"), std::string::npos);
+}
+
 int main(int argc, char *argv[])
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## [ISSUE #6][DIAGRAMS] Add possibility to specify the background color of the generated diagrams

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Are all unit tests still pass successfully after your changes?

#### Change description:

-  Extension of DMA_Plantuml API. Addition of the possibility to specify the background color of the generated diagrams
- Creation of unit-test, which covers the new functionality.

#### Verification criteria:

Checked manually on Windows OS
All sanity checks on the Github were passed