### PR TITLE
[ISSUE #17][BUILD_FAILURE] DMA_Plantuml.cpp: error C2039: 'tolower': is not a member of 'std'

### DIFF
--- a/DMA_Plantuml/src/DMA_Plantuml.cpp
+++ b/DMA_Plantuml/src/DMA_Plantuml.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <fstream>
+#include <cctype>
 
 #include "DMA_Plantuml.hpp"
 


### PR DESCRIPTION
## [ISSUE #17][BUILD_FAILURE] DMA_Plantuml.cpp: error C2039: 'tolower': is not a member of 'std'

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Are all unit tests still pass successfully after your changes?

#### Change description:

- Add the missing cctype include, which is causing build failure on the Windows OS. Probably other used build toolchains were including cctype header internally.

#### Verification criteria:

- Was checked by the user, who has created an issue.